### PR TITLE
reenable inline functions on windows by updating bindgen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,5 @@ links = "skia"
 
 [build-dependencies]
 cc = "1"
-bindgen = "0.46"
+# temporary, 47.2 will contain the changes that are required to support inline functions on windows.
+bindgen = { git = "https://github.com/rust-lang/rust-bindgen", rev = "49b74244f7db8618b9a1b135ce2659751636c59c" } 

--- a/build.rs
+++ b/build.rs
@@ -114,13 +114,9 @@ fn main() {
 
 fn bindgen_gen(current_dir_name: &str) {
 
-  // don't generate inline function on windows,
-  // bindgen produces the following error:
-  // "std__Atomic_impl__Atomic_impl<_Bytes>" is not a valid Ident
-  let inline_functions = !cfg!(windows);
-
   let mut builder = bindgen::Builder::default()
-    .generate_inline_functions(inline_functions)
+    .generate_inline_functions(true)
+
     .whitelist_function("SkiaCreateCanvas")
     .whitelist_function("SkiaCreateRect")
     .whitelist_function("SkiaClearCanvas")


### PR DESCRIPTION
Fixes #7 